### PR TITLE
Simplified

### DIFF
--- a/mystuff.py
+++ b/mystuff.py
@@ -1,37 +1,39 @@
+import sys 
+
 import numpy as np
 from collections import OrderedDict
-
 import scanner
 
 parameters = OrderedDict()
 
-# EDIT HERE
-run_id = '180215_1029'
-parameters['tail_veto_threshold']  = [1e4, 1e5],
-parameters['tail_veto_pass_fraction'] = [0.1, 0.2]
-
-# DO NOT EDIT BELOW
-
-keys = list(parameters.keys())
-values = list(parameters.values())
-
-combination_values = np.array(np.meshgrid(*values)).T.reshape(-1,
-                                                              len(parameters))
-
-strax_options = []
-for i, value in enumerate(combination_values):
-    print('Setting %d:' % i)
-    config = {}
-    for j, parameter in enumerate(value):
-          print('\t', keys[j], parameter)
-          config[keys[j]] = parameter
-    strax_options.append({'run_id' : run_id, 'config' : config})
-    print()
-
-print(strax_options)
-
-scanner.scan_parameters(strax_options)
+# IF YOU WANT TO REGISTER YOUR OWN PLUGIN FOR THE SCAN, USE THESE LINES. 
+# In case you want to register any non-standard plugins which is not part of the offical straxen 
+# you have to specify the path where the .py file with the plugin can be found:
+sys.path.append('/path/to/your/plugin/')
+# and import it.
+import MyPlugin # Or whatever your plugin is named. Skip if not doing plugin.
 
 
 
+target = ''
+name = 'me' # A short (<5 characters?) name to find your scanner among the masses of jobs. Initials are good.
+output_directory = './strax_data'
+# Plugins to be registered, can be None, single Plugin or a list of Plugins.
+register = HitCounting 
 
+#Specify here all of the config settings you want to look at. 
+paramter_dict = {'run_id': run_id, # can also be a list of run_ids. 
+                 'threshold': 15,
+                 'save_outside_hits_left': [10, 20, 30, 40],
+                 'save_outside_hits_right': [100, 120, 140, 160, 180, 200, 220, 240, 260]}
+
+#scan over everything in strax_options. scanner.py will enumerate over all that you've provided. 
+scanner.scan_parameters(target,
+                        paramter_dict,
+                        register=register,
+                        output_directory=output_directory,
+                        name=f'{name}_scan',
+                        job_config={'n_cpu': 2, 
+                                    'max_hours': 1},
+                        xenon1t=False
+                       )

--- a/scanner.py
+++ b/scanner.py
@@ -259,13 +259,13 @@ def work(run_id,
         st = straxen.context.xenon1t_dali(output_folder=output_folder)
         st.set_config(**config)
         st.register(register)
-        st.make(run_id, target, max_worker=kwargs.get('n_cpu', 40), **kwargs)
+        st.make(run_id, target, max_worker=kwargs.get('n_cpu', 4), **kwargs)
     else:
         st = straxen.contexts.xenonnt_online(register=register,
                                              output_folder=output_folder,
                                              config=config
                                             )
-        st.make(run_id, target, max_worker=kwargs.get('n_cpu', 40), **kwargs)
+        st.make(run_id, target, max_worker=kwargs.get('n_cpu', 4), **kwargs)
     
     
 

--- a/scanner.py
+++ b/scanner.py
@@ -1,3 +1,4 @@
+print('Please stand-by submission is initalized, this may take a moment.\n')
 import json
 import logging
 import os
@@ -7,11 +8,11 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections import OrderedDict
+
 
 import numpy as np
-import pandas as pd
 
-import strax
 import straxen
 
 #SBATCH --job-name=scanner_{name}_{config}                                                             
@@ -29,108 +30,211 @@ JOB_HEADER = """#!/bin/bash
 #SBATCH --output={log_fn}
 #SBATCH --error={log_fn}
 {extra_header}
-
 # Conda
 . "{conda_dir}/etc/profile.d/conda.sh"
 {conda_dir}/bin/conda activate {env_name}
-
 echo Starting scanner
-
 python {python_file} {run_id} {data_path} {config_file} 
 """
 
 
-def scan_parameters(strax_options=[{'run_id' : '180215_1029', 'config' : {'tail_veto_threshold' : 1e5, 
-                                                                          'tail_veto_pass_fraction' : 0.05}},
-                                   {'run_id' : '180215_1029', 'config' : {'other_options': 3}},],
-                    directory=os.getcwd() + '/parameter_scan',
+def scan_parameters(target,
+                    parameter,
+                    name,
+                    register=None,
+                    output_directory='./strax_data',
+                    job_config=None,
+                    log_directory='./parameter_scan',
+                    xenon1t=False,
                     **kwargs):
     """Called in mystuff.py to run specified jobs. 
     
-    This main function goes through and runs jobs based on the options given in strax.
-    Currently this is constructed to call submit_setting, which then eventually starts a job and proceeds to get a dataframe of event_info, thereby processing all data for specified runs.
-
+    This main function goes through and runs jobs based on the options 
+    given in strax. Currently this is constructed to call 
+    submit_setting, which then eventually starts a job and proceeds to 
+    get a dataframe of event_info, thereby processing all data for 
+    specified runs. 
+    
     Params: 
     strax_options: a dictionary which must include:
         - 'run_id' (default is '180215_1029')
         - 'config' (strax configuration options)
-        - A directory to save the job logs in. Default is current directory in a new file.
-        - kwargs: max_hours, extra_header, n_cpu, ram (typical dali job sumission arguments apply.)
+        - A directory to save the job logs in. Default is current 
+            directory in a new file.
+        - kwargs: max_hours, extra_header, n_cpu, ram (typical dali job 
+            sumission arguments apply.)
     """
+    assert 'run_id' in parameter.keys(), 'No run_id key found in parameters.' 
+    # List of todos, or things we could change as well:
+    #TODO: this function does not support a chnage of context yet. 
+    #        * But should be possible to make it an argument.
+    config_list = _make_config(parameter)
+    
+    # I guess it will happen from time to time that somebody messes up....
+    # So let us people explicitly confirm their submission before they start
+    # hundrets of jobs.... 
+    _user_check()
+    
+    # Displaying the job-settings: as well:
+    default_job_config = {'job_name': name,
+                          'n_cpu': 4,
+                          'max_hours': 8,
+                          'mem-per-cpu': 4480,
+                          'partition': 'dali',
+                          'conda_dir': '/dali/lgrandi/strax/miniconda3',
+                          'extra_sbatch_header': ''
+                         }
+    # Update default settings:
+    if job_config:
+        for key, value in job_config.items():
+            if key in default_job_config.keys():
+                default_job_config['key'] = value
+            else:
+                raise ValueError(f'Job settings {key} is not supported.')
+    
+    # Lets print the settings and ask the user again:
+    print('\nYou specified the following settings for the batch jobs:')
+    for key, value in default_job_config.items():
+        print(f'{key}:   {value}')
+    _user_check()
+    return 0
+    
     
     # Check that directory exists, else make it
-    if not os.path.exists(directory):
-        os.makedirs(directory)
+    if not os.path.exists(log_directory):
+        os.makedirs(log_directory)
 
     # Submit each of these, such that it calls me (parameter_scan.py) with submit_setting option
-    for i, strax_option in enumerate(strax_options):
-        print('Submitting %d with %s' % (i, strax_option))
-        submit_setting(directory=directory, **strax_option)
-
+    for i, config in enumerate(config_list):
+        print('Submitting %d with %s' % (i, config))
+        submit_setting(target,
+                       name,
+                       register,
+                       config,
+                       output_directory,
+                       default_job_config,
+                       log_directory,
+                       xenon1t,
+                       **kwargs
+                      )
     pass
 
-def submit_setting(run_id, config, directory, **kwargs):
+
+def _user_check():
+    not_correct_answer = True
+    answer = input('Are you sure you would like to submit these settings? (y/n)')
+    while not_correct_answer:
+        if answer=='y':
+            print('Proceeding with the submission.')
+            not_correct_answer = False
+        elif answer=='n':
+            print('Abord submission.')
+            raise SystemExit(0)
+        else:
+            answer = input(f'{answer} was not a valid input please use (y/n) for yes/no.')
+    
+
+def _make_config(parameters_dict):
+    # Converting any dict to ordered dict, might be a bit more user 
+    # friendly.    
+    parameters = OrderedDict()
+    for key, values in parameters_dict.items():
+        print(key, values)
+        parameters[key] = values
+
+    keys = list(parameters.keys())
+    values = list(parameters.values())
+
+    #Make a meshgrid of all the possible parameters we have, for scanning purposes.
+    combination_values = np.array(np.meshgrid(*values)).T.reshape(-1,
+                                                                  len(parameters))
+
+    strax_options = []
+
+    #Enumerate over all possible options to create a strax_options list for scanning later.
+    for i, value in enumerate(combination_values):
+        print('Setting %d:' % i)
+        config = {}
+        for j, parameter in enumerate(value):
+            print('\t', keys[j], parameter)
+            config[keys[j]] = parameter
+        strax_options.append(config)
+    return strax_options
+
+
+def submit_setting(run_id, # do we need this line? Don't think it should be in here. 
+                   target,
+                   name,
+                   register,
+                   config,
+                   output_directory,
+                   job_config,
+                   log_directory,
+                   xenon1t,
+                   **kwargs):
     """
     Submits a job with a certain setting.
     
-    Given input setting arguments, submit_setting will take a current run and submit a job to dali that calles this code itself (so not runs scanner.py directly.) First, files are created temporarily in directory (arg) that document what you have submitted. These are then used to submit a typical job to dali. This then bumps us down to if __name__ == '__main__' since we call it directly. You could alternatively switch this so that if we submit_setting we run a different file. 
+    Given input setting arguments, submit_setting will take a current 
+    run and submit a job to dali that calles this code itself (so not 
+    runs scanner.py directly.) First, files are created temporarily in 
+    directory (arg) that document what you have submitted. These are 
+    then used to submit a typical job to dali. This then bumps us down 
+    to if __name__ == '__main__' since we call it directly. You could 
+    alternatively switch this so that if we submit_setting we run a 
+    different file. 
     
     Arguments:
-    run_id (str): run id of the run to submit the job for. Currently not tested if multiple run id's work but they should
-    config (dict): a dictionary of configuration settings to try (see strax_options in mystuff.py for construction of these config settings)
-    directory (str): Place where the job logs will get saved. These are short files just with the parameters saved and log of what happened, but can be useful in debugging.
+    run_id (str): run id of the run to submit the job for. Currently not 
+        tested if multiple run id's work but they should.
+    config (dict): a dictionary of configuration settings to try (see 
+        strax_options in mystuff.py for construction of these config 
+        settings)
+    directory (str): Place where the job logs will get saved. These are 
+        short files just with the parameters saved and log of what 
+        happened, but can be useful in debugging.
+    
     **kwargs (optional): can include the following
-        - n_cpu : numbers of cpu for this job. Default 40. Decreasing this to minimum needed will get your job to submit to dali faster!
+        - n_cpu : numbers of cpu for this job. Default 40. Decreasing 
+            this to minimum needed will get your job to submit to dali
+            faster!
         - max_hours: max hours to run job. Default 8
-        - name: the appendix you want to scan_{name} which shows up in dali. Defaults "magician" if not specified so change if you're not a wizard.
-        - mem_per_cpu: (MB) default is 4480 MB for RAM per CPU. May need more to run big processing.
+        - name: the appendix you want to scan_{name} which shows up in 
+            dali. Defaults "magician" if not specified so change if 
+            you're not a wizard.
+        - mem_per_cpu: (MB) default is 4480 MB for RAM per CPU. May need 
+            more to run big processing.
         - partition: Default to dali
-        - conda_dir: Where is your environment stored? Default is /dali/lgrandi/strax/miniconda3 (for backup strax env). Change?
-        - env_name: Which conda env do you want, defaults to strax inside conda_dir
+        - conda_dir: Where is your environment stored? Default is 
+            /dali/lgrandi/strax/miniconda3 (for backup strax env). 
+            Change?
+        - env_name: Which conda env do you want, defaults to strax 
+            inside conda_dir
     """
     
     job_fn = tempfile.NamedTemporaryFile(delete=False,
-                                         dir=directory).name
+                                         dir=log_directory).name
     log_fn = tempfile.NamedTemporaryFile(delete=False,
-                                         dir=directory).name
+                                         dir=log_directory).name
 
     config_fn = tempfile.NamedTemporaryFile(delete=False,
-                                            dir=directory).name
+                                            dir=log_directory).name
     
     #Takes configuration parameters and dumps the stringed version into a file called config_fn
     with open(config_fn, mode='w') as f:
         json.dump(config, f)
 
-
-    # TODO: move these default settings out to above somehow.  Maybe a default dictionary
-    # that gets overloaded?
     with open(job_fn, mode='w') as f:
         # Rename such that not just calling header, I think this is done now, no?
         # TODO PEP8
-        f.write(JOB_HEADER.format(  
+        f.write(JOB_HEADER.format(
+            **job_config,
             log_fn=log_fn,
-            config=str(config),
             python_file=os.path.abspath(__file__),
             config_file = config_fn,
-            name = kwargs.get('job_name',
-                              'magician'),
-            n_cpu=kwargs.get('n_cpu',
-                             40),            
-            max_hours=kwargs.get('max_hours',
-                                 8),
-            mem_per_cpu=kwargs.get('mem-per-cpu',
-                                   4480),
-            partition=kwargs.get('partition',
-                                    'dali'),
-            conda_dir=kwargs.get('conda_dir',
-                                 '/dali/lgrandi/strax/miniconda3'),
-            env_name=kwargs.get('env_name', 'strax'),
-            run_id=kwargs.get('run_id',
-                               '180215_1029'),
-            data_path=kwargs.get('data_path', 
-                                 '/dali/lgrandi/andaloro/strax_data'), #Need to not make mine somehow.
-            extra_header=kwargs.get('extra_header',
-                                    ''),
+            name=name,
+            run_id=config['run_id'],
+            data_path=output_directory, 
         ))
     print(sys.argv)
 
@@ -142,37 +246,48 @@ def submit_setting(run_id, config, directory, **kwargs):
 
     print("\tYou have job id %d" % job_id)
 
-def work(run_id, data_path, config, save_df=False, **kwargs):
-    st = straxen.contexts.strax_workshop_dali()
+
+def work(run_id, 
+         target,  
+         config, 
+         output_folder='./strax_data',
+         register=None, 
+         xenon1t=False,
+         **kwargs):
+    if xenon1T:
+        # XENON1T env is not as flexiable as the nT env...
+        st = straxen.context.xenon1t_dali(output_folder=output_folder)
+        st.set_config(**config)
+        st.register(register)
+        st.make(run_id, target, max_worker=kwargs.get('n_cpu', 40), **kwargs)
+    else:
+        st = straxen.contexts.xenonnt_online(register=register,
+                                             output_folder=output_folder,
+                                             config=config
+                                            )
+        st.make(run_id, target, max_worker=kwargs.get('n_cpu', 40), **kwargs)
     
-    st.storage[-1] = strax.DataDirectory(data_path,
-                                         provide_run_metadata=False)
-    path_to_df = 'scanner_dfs/'
-    df = st.get_df(run_id,
-                        'event_info',
-                        config=config,
-                        max_workers = kwargs.get('n_cpu', 
-                                                 40))
-    if save_df = True: #For Sophia 
-        veto_st = "{:.0f}".format(config['tail_veto_threshold'])
-        pass_st = "{:.0f}".format(config['tail_veto_pass_fraction']*config['tail_veto_threshold'])
-        key_temp = 'he_val'+ veto_st + 'pass_tot' + pass_st
-        df.to_hdf(path_to_df + key_temp + '.h5', key = key_temp, mode='a')
+    
 
 if __name__ == "__main__": #happens if submit_setting() is called
     if len(sys.argv) == 1: # argv[0] is the filename
         print('hi I am ', __file__)
         scan_parameters()
-    elif len(sys.argv) == 4:
+    elif len(sys.argv) == 5:
         run_id = sys.argv[1]
-        data_path = sys.argv[2]
+        target = sys.argv[2]
         config_fn = sys.argv[3]
+        output_folder = sys.argv[4]
         print(run_id, data_path, config_fn)
         print("Things are changing")
         # Reread the config file to grab the config parameters
         with open(config_fn, mode='r') as f:
             config = json.load(f)
+        work(run_id=run_id, 
+             target=target, 
+             register=config['register'], 
+             output_folder=data_path, 
+             config=config)
         
-        work(run_id=run_id, data_path=data_path, config=config, max_workers=40)
     else:
         raise ValueError("Bad command line arguments")


### PR DESCRIPTION
This was brought on by Daniel's suggestion to allow for registered plugins to be passed as an argument to the scan function. If desired that can now be done. Otherwise leave the option as None. 
